### PR TITLE
Pull tremor docs as part of build process

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tremor-www-docs"]
-	path = tremor-www-docs
-	url = git@github.com:wayfair-tremor/tremor-www-docs.git
+  path = tremor-www-docs
+  url = https://github.com/wayfair-tremor/tremor-www-docs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tremor-www-docs"]
+	path = tremor-www-docs
+	url = git@github.com:wayfair-tremor/tremor-www-docs.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "tremor-language-server"
-version = "0.7.0"
+version = "0.7.3"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "tremor-language-server"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tremor-language-server"
-version = "0.7.0"
+version = "0.7.3"
 description = "Tremor Language Server (Trill)"
 authors = ["The Tremor Team"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tremor-language-server"
-version = "0.1.0"
+version = "0.7.0"
 description = "Tremor Language Server (Trill)"
 authors = ["The Tremor Team"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ nice-to-have: rename all references
 ```sh
 cd ~/repos
 git clone git@github.com:wayfair-tremor/tremor-language-server.git
-git clone git@github.com:wayfair-tremor/tremor-www-docs.git # needed to generate data for function doc completions
 cd tremor-language-server
 
 # during development
@@ -182,7 +181,6 @@ If you prefer not to use ale, these vim plugins should also work well as the ser
 
 ## TODO
 
-* pull docs release file as part of build process (for function completions)
 * integration for emacs
 * support parallel edits for trickle and tremor files
 * improve debugging


### PR DESCRIPTION
Stores tremor docs repo as a git submodule. The repo is then used as part of the language server build process, for generating the function documentation as well as module completion items. Once we store those items in a structured way as part of the tremor-script codebase, this won't be needed.

This also enables us to publish the language server to crates.io, since the build does not depend on manual clone of the docs repo now.