### PR TITLE
Simplify cargo installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,6 +2304,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde_json",
+ "simd-json",
  "tar",
  "tokio",
  "tower-lsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tremor-language-server"
-version = "0.8.1"
+version = "0.8.2"
 description = "Tremor Language Server (Trill)"
 authors = ["The Tremor Team"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [build-dependencies]
-bincode = "1.2.1"
+bincode = "1.2"
 glob = "0.3"
 home = "0.5"
 regex = "1.3"
@@ -25,10 +25,18 @@ reqwest = "0.10"
 # tremor deps
 tremor-script = "0.8.1"
 
+# use non-simd fallback with simd-json so that we can install tremor-language-server
+# without needing to configure cpu target for simd-json compilation
+# https://github.com/simd-lite/simd-json#cpu-target
+#
+# this is fine for language server use since we don't care as much for json
+# processing performance here (easy installation is more important for users)
+simd-json = { "version" = "0.3", "features" = ["allow-non-simd"] }
+
 [dependencies]
 
-bincode = "1.2.1"
-clap = "2.33.1"
+bincode = "1.2"
+clap = "2.33"
 
 halfbrown = "0.1"
 jsonrpc-core = "14.1"


### PR DESCRIPTION
To install tremor-language-server 0.8.1 from crates.io, users have to configure cpu target as per https://github.com/simd-lite/simd-json#cpu-target (for the simd-json dependency that comes via tremor-script currently).

Example:
```
RUSTFLAGS="-C target-cpu=native" cargo install tremor-language-server
```

Needed configuration is there in the project `.cargo`:
https://github.com/wayfair-tremor/tremor-language-server/blob/v0.8.1/.cargo/config

But this file is [not read](https://github.com/rust-lang/cargo/pull/6026) during `cargo install` so it only works for builds straight from the git repo.

To simplify the installation process, this MR opts to use simd-json with `allow-non-simd` feature. Ease of installation is more important for tremor-language-server rather than json processing performance so this should be fine to do.

---

We had similar behavior in v0.7.4 but it got removed as part of 0.8 release here: https://github.com/wayfair-tremor/tremor-language-server/commit/c45b23cb44cbf6ca2260df2132a9efd4c8eb67b4

Now we specify simd-json only as build-dependency. If we choose to add a `allow-non-simd` feature to tremor-script (pointing to the simd-json feature of the same name), we can revisit this MR (that might be better than adding a simd-json dependency here, which is not really used directly in trill). 

---

Verified as working via:

```
cargo install --git https://github.com/wayfair-tremor/tremor-language-server.git --branch simplify_cargo_install
```

