### PR TITLE
Upgrade to tower-lsp 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8236aa744f63f15ab625781c234ba97571168b768f29b83d6e5112c3f8ba21"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,12 +651,6 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
-
-[[package]]
-name = "futures"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
@@ -724,7 +730,6 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
- "futures 0.1.29",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -836,6 +841,15 @@ dependencies = [
  "flate2",
  "nom 5.1.1",
  "num-traits",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1000,31 +1014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-core"
-version = "14.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
-dependencies = [
- "futures 0.1.29",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-derive"
-version = "14.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn",
-]
-
-[[package]]
 name = "jumphash"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.74.1"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0e6a2b8837d27b29deb3f3e6dc1c6d2f57947677f9be1024e482ec5b59525"
+checksum = "7f1f86677fdbe8df5f88b99131b1424e50aad27bbe3e5900d221bc414bd72e9b"
 dependencies = [
  "base64 0.12.1",
  "bitflags",
@@ -1504,12 +1493,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "proc-macro-crate"
-version = "0.1.4"
+name = "proc-macro-error"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
- "toml",
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn",
+ "version_check 0.9.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn",
+ "syn-mid",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -2112,6 +2118,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,26 +2256,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "tower-lsp"
-version = "0.11.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a96bbd107e83d4558bcd881fd8fc8eda7dbbd3ad2f013829be4aa7948d8f0"
+checksum = "a17297f73c118d71cde4c823100ec63fa0477fbd4e565a7e2ffd4d4f1c1fafda"
 dependencies = [
  "async-trait",
+ "auto_impl",
  "bytes",
  "dashmap",
- "futures 0.3.5",
- "jsonrpc-core",
- "jsonrpc-derive",
+ "futures",
  "log",
  "lsp-types",
  "nom 5.1.1",
@@ -2266,7 +2273,20 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "tower-lsp-macros",
  "tower-service",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c51c24e3b5909be30d6ed472f934aa9b7d91abf2688013956b296b1d1e7b186"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -2302,11 +2322,10 @@ dependencies = [
  "bincode",
  "clap",
  "flate2",
- "futures 0.3.5",
+ "futures",
  "glob",
  "halfbrown",
  "home",
- "jsonrpc-core",
  "regex",
  "reqwest",
  "serde_json",
@@ -2396,6 +2415,12 @@ checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,9 @@ bincode = "1.3"
 clap = "2.33"
 
 halfbrown = "0.1"
-jsonrpc-core = "14.2"
 serde_json = "1.0.57"
 tokio = { version = "0.2", features = ["io-std", "macros", "sync"] }
-tower-lsp = "0.11"
+tower-lsp = "0.13"
 
 # tremor deps
 tremor-script = "0.8.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn main() {
             let stdin = tokio::io::stdin();
             let stdout = tokio::io::stdout();
 
-            let (service, messages) = LspService::new(Backend::new(language));
+            let (service, messages) = LspService::new(|client| Backend::new(client, language));
             Server::new(stdin, stdout)
                 .interleave(messages)
                 .serve(service)


### PR DESCRIPTION
### Changed

* Upgrade to `tower-lsp` 0.13.1.

### Removed

* Remove `jsonrpc-core` dependency.

I noticed that #79 was failing in CI due to upstream API changes, so I decided to send a PR your way. 😄  No breakage in runtime behavior is expected, but please do verify with your editor that everything still works as expected. If you notice any bugs or other issues, feel free to ping me directly!

**Highlighted changes since 0.11.0 include:**

* Update `lsp-types` from 0.74 to 0.79, which includes new protocol features and schema bug fixes.
* Have language server backends store `Client` as a struct field.
* Make all `Client` methods `async fn`.
* Implement `$/cancelRequest` support.
* Add support for serving over TCP.
* Fix broken handling of `workspace/didChangeConfiguration` due to a typo.
* Remove `jsonrpc-core` dependency.
* Eliminate internal `tokio::spawn` calls and nearly all `tokio`-specific code.
* Return responses in corresponding request order to reduce work on the client side.
* Less noisy log messages and better quality JSON-RPC error responses.
* More resilient LSP message parsing.
* Better API documentation.

See the full release notes for [0.12.0](https://github.com/ebkalderon/tower-lsp/releases/tag/v0.12.0), [0.12.1](https://github.com/ebkalderon/tower-lsp/releases/tag/v0.12.1), [0.13.0](https://github.com/ebkalderon/tower-lsp/releases/tag/v0.13.0), [0.13.1](https://github.com/ebkalderon/tower-lsp/releases/tag/v0.13.1) for reference.