### PR TITLE
Fix running the server on windows

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -356,9 +356,9 @@ impl LanguageServer for Backend {
 
 // TODO remove. just for testing right now
 pub fn file_dbg(name: &str, content: &str) {
+    use std::env::temp_dir;
     use std::fs::File;
     use std::io::Write;
-    use std::env::temp_dir;
     use std::path::PathBuf;
 
     let mut path = PathBuf::new();


### PR DESCRIPTION
This isn't ideal, as the whole `file_dbg` function seems like something that shouldn't be here and probably replaced with a logging framework, but this is the minimal change required to make the language server not crash on startup on windows.