### PR TITLE
Update github workflows and add coveralls

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -6,13 +6,13 @@ jobs:
   license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Check license headers
         run: ./.github/checks/copyright.sh
   sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: Safety checks
@@ -24,7 +24,7 @@ jobs:
         run: sudo snap install remarshal
       - name: Install deps
         run: sudo snap install --classic ripgrep
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: Check for unused dependencies
@@ -32,30 +32,57 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
+          profile: minimal
+          components: rustfmt
       - name: Check Formating
         run: cargo fmt --all -- --check
   clippy-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - uses: Swatinem/rust-cache@v1
       - name: Install deps
-        run: |
-            sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1
+        run: sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
-      - name: Install clippy
-        run: rustup component add clippy
+          profile: minimal
+          toolchain: stable
+          components: clippy
+      - name: Check workflow permissions
+        id: check_permissions
+        uses: scherermichael-oss/action-has-permission@1.0.6
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clippy action to produce annotations
+        uses: actions-rs/clippy-check@v1
+        if: steps.check_permissions.outputs.has-permission
+        with:
+          args: --all
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clippy manually without annotations
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: cargo clippy --all
+
+
+
+
+
+
+
+
+
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -6,5 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -6,7 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - uses: actions-rs/audit-check@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   tests-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: Install deps [Linux]
@@ -14,14 +14,16 @@ jobs:
             sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1
       - uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --all --locked
   code-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       - name: Install deps
@@ -31,14 +33,16 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v1
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         env:
           RUSTFLAGS: -C target-cpu=native
         with:
-          version: '0.18.0-alpha3'
-          args: ' --avoid-cfg-tarpaulin --exclude-files target* --all'
-      - uses: codecov/codecov-action@v1
+          version: '0.18.0'
+          args: ' --avoid-cfg-tarpaulin --exclude-files target* --all --out Lcov'
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: ./cobertura.xml
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          path-to-lcov: ./lcov.info


### PR DESCRIPTION
This also adds a workaround for executing clippy for PRs from forks, where it currently fails.